### PR TITLE
fix: return contrast as float with 2 decimals

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ const getContrastRatio = (color1, color2) => {
 
   const contrast = (lightest + 0.05) / (darkest + 0.05);
 
-  return Math.floor(contrast, -2);
+  return parseFloat(contrast.toFixed(2));
 };
 
 export default getContrastRatio;

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ const getContrastRatio = (color1, color2) => {
 
   const contrast = (lightest + 0.05) / (darkest + 0.05);
 
-  return parseFloat(contrast.toFixed(2));
+  return parseFloat(parseFloat(contrast).toFixed(2));
 };
 
 export default getContrastRatio;

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ const getContrastRatio = (color1, color2) => {
 
   const contrast = (lightest + 0.05) / (darkest + 0.05);
 
-  return parseFloat(parseFloat(contrast).toFixed(2));
+  return Math.floor(contrast * 100) / 100;
 };
 
 export default getContrastRatio;


### PR DESCRIPTION
Before `Math.floor(contrast, -2)` was used. I think the intended effect was to round the contrast to two decimals. Unfortunately this doesn't work. The new implementation should be correct.